### PR TITLE
Refactor FavoriteListUseCase fetchList

### DIFF
--- a/AnotherPokemonAssignment/AnotherPokemonAssignment/UseCase/FavoriteListUseCase.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignment/UseCase/FavoriteListUseCase.swift
@@ -18,11 +18,8 @@ final class FavoriteListUseCase: ListUseCaseSpec {
     }
 
     func fetchList(offset: Int) async throws -> [Pokemon] {
-        await withUnsafeContinuation { continuation in
-            let pokemons = getPokemons(limit: limit, offset: offset)
-                .map { Pokemon(name: $0.name, id: $0.id) }
-            continuation.resume(returning: pokemons)
-        }
+        getPokemons(limit: limit, offset: offset)
+            .map { Pokemon(name: $0.name, id: $0.id) }
     }
 }
 


### PR DESCRIPTION
## Summary
- simplify `FavoriteListUseCase.fetchList` by returning `[Pokemon]` directly

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b320a19c832d8231d1d4423b5437