### PR TITLE
Fix redundant store access in PokemonStoreUseCase

### DIFF
--- a/AnotherPokemonAssignment/AnotherPokemonAssignment/UseCase/PokemonStoreUseCase.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignment/UseCase/PokemonStoreUseCase.swift
@@ -44,7 +44,7 @@ private extension PokemonStoreUseCase {
         defer {
             store.savePokemons(pokemons)
         }
-        guard let index = store.getPokemons().firstIndex(where: { $0.id == pokemon.id }) else {
+        guard let index = pokemons.firstIndex(where: { $0.id == pokemon.id }) else {
             pokemons.append(pokemon)
             return
         }


### PR DESCRIPTION
## Summary
- avoid fetching from the store twice when saving a Pokemon

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6841b31bbe14832dadb18da4126e9369