### PR TITLE
Switch tests to Swift Testing

### DIFF
--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/Helper.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/Helper.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
 enum Helper {
@@ -48,25 +48,19 @@ struct ListServiceStub: GetListSpec {
     }
 }
 
-extension XCTestCase {
-    var dummyID: String {
-        "1"
-    }
+let dummyID = "1"
 
-    var dummyName: String {
-        "a"
-    }
+let dummyName = "a"
 
-    var listStubData: Data{
-            """
+var listStubData: Data {
+    """
+    {
+        "results": [
             {
-                "results": [
-                    {
-                        "name": "\(dummyName)",
-                        "url": "https://pokeapi.co/api/v2/ability/\(dummyID)/"
-                    }
-                ]
+                "name": "\(dummyName)",
+                "url": "https://pokeapi.co/api/v2/ability/\(dummyID)/"
             }
-            """.data(using: .utf8)!
+        ]
     }
+    """.data(using: .utf8)!
 }

--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/Networking/PokemonServiceTest.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/Networking/PokemonServiceTest.swift
@@ -5,14 +5,14 @@
 //  Created by Mark Chen on 2023/4/14.
 //
 
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
-final class PokemonServiceTest: XCTestCase {
+@Suite struct PokemonServiceTest {
     func test_pokemonService_successEntityStub() async throws {
         let sut = makeSUT(stub: SuccessStub())
         let entity: SuccessEntity = try await sut.fetch(path: Helper.dummyPath, query: nil)
-        XCTAssertEqual(entity.foo, "bar")
+        #expect(entity.foo == "bar")
     }
 
     func test_pokemonService_errorStub500_shouldThrowInvalidStatusCodeError() {
@@ -20,9 +20,9 @@ final class PokemonServiceTest: XCTestCase {
             do {
                 let sut = makeSUT(stub: ErrorStub())
                 let _: SuccessEntity = try await sut.fetch(path: Helper.dummyPath, query: nil)
-                XCTFail("should throw error")
+                #expect(false, because: "should throw error")
             } catch {
-                XCTAssertEqual(error as! PokemonServiceError, PokemonServiceError.invalidStatusCode)
+                #expect((error as? PokemonServiceError) == PokemonServiceError.invalidStatusCode)
             }
         }
     }

--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/Networking/RequestTest.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/Networking/RequestTest.swift
@@ -5,16 +5,16 @@
 //  Created by Mark Chen on 2023/4/13.
 //
 
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
-final class RequestTest: XCTestCase {
+@Suite struct RequestTest {
     func test_request_init() throws {
         let sut = makeSUT(path: dummyPath)
         let request = try sut.makeToURLRequest()
 
-        XCTAssertEqual(request.url?.absoluteString, "https://pokeapi.co\(dummyPath)")
-        XCTAssertEqual(request.httpMethod, "GET")
+        #expect(request.url?.absoluteString == "https://pokeapi.co\(dummyPath)")
+        #expect(request.httpMethod == "GET")
     }
 
 
@@ -25,7 +25,7 @@ final class RequestTest: XCTestCase {
         let query = components.queryItems!
             .map { "\($0.name)=\($0.value!)" }
             .joined(separator: "&")
-        XCTAssertEqual(query, "q1=v1&q3=v3")
+        #expect(query == "q1=v1&q3=v3")
     }
 }
 

--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/Service/PokemonRequestMakerTest.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/Service/PokemonRequestMakerTest.swift
@@ -5,14 +5,14 @@
 //  Created by Mark Chen on 2023/4/14.
 //
 
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
-final class PokemonRequestMakerTest: XCTestCase {
+@Suite struct PokemonRequestMakerTest {
     func test_pokemonRequestMaker_PokemonRequest() throws {
         let sut = makeSUT(path: "poke", query: [("q1", "v1")])
         let url = try sut.makeToURLRequest().url
-        XCTAssertEqual(url?.absoluteString, "https://pokeapi.co/api/v2/poke?q1=v1")
+        #expect(url?.absoluteString == "https://pokeapi.co/api/v2/poke?q1=v1")
     }
 }
 

--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/UseCase/DetailUseCaseTest.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/UseCase/DetailUseCaseTest.swift
@@ -5,24 +5,24 @@
 //  Created by Mark Chen on 2023/4/17.
 //
 
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
-final class DetailUseCaseTest: XCTestCase {
+@Suite struct DetailUseCaseTest {
     func test() async throws {
         let dummyWeight = 1
         let dummyHeight = 2
         let dummyType = "type"
         let sut = makeSUT(weight: dummyWeight, height: dummyHeight, type: dummyType)
         let model = try await sut.fetchDetail()
-        XCTAssertEqual(String(model.id), dummyID)
-        XCTAssertEqual(model.weight, dummyWeight)
-        XCTAssertEqual(model.height, dummyHeight)
-        XCTAssertEqual(model.type, dummyType)
-        XCTAssertEqual(model.idText, "id: \(dummyID)")
-        XCTAssertEqual(model.weightText, "weight: \(dummyWeight)")
-        XCTAssertEqual(model.heightText, "height: \(dummyHeight)")
-        XCTAssertEqual(model.typeText, "type: \(dummyType)")
+        #expect(String(model.id) == dummyID)
+        #expect(model.weight == dummyWeight)
+        #expect(model.height == dummyHeight)
+        #expect(model.type == dummyType)
+        #expect(model.idText == "id: \(dummyID)")
+        #expect(model.weightText == "weight: \(dummyWeight)")
+        #expect(model.heightText == "height: \(dummyHeight)")
+        #expect(model.typeText == "type: \(dummyType)")
     }
 }
 

--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/UseCase/FavoriteListUseCaseTest.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/UseCase/FavoriteListUseCaseTest.swift
@@ -5,32 +5,32 @@
 //  Created by Mark Chen on 2023/4/17.
 //
 
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
-final class FavoriteListUseCaseTest: XCTestCase {
+@Suite struct FavoriteListUseCaseTest {
     func test_favoriteListUseCase_offset_startIndexIsZero() async throws {
         let sut = makeSUT(pokemons: dummyPokemons)
         let pokemons = try await sut.fetchList(offset: 0)
-        XCTAssertEqual(pokemons.count, 3)
+        #expect(pokemons.count == 3)
     }
 
     func test_favoriteListUseCase_offset_startIndexIsOne() async throws {
         let sut = makeSUT(pokemons: dummyPokemons)
         let pokemons = try await sut.fetchList(offset: 1)
-        XCTAssertEqual(pokemons.count, 2)
+        #expect(pokemons.count == 2)
     }
 
     func test_favoriteListUseCase_offset_startIndexAboveItemCount() async throws {
         let sut = makeSUT(pokemons: dummyPokemons)
         let pokemons = try await sut.fetchList(offset: 4)
-        XCTAssertEqual(pokemons.isEmpty, true)
+        #expect(pokemons.isEmpty == true)
     }
 
     func test_favoriteListUseCase_emptyPokemons() async throws {
         let sut = makeSUT(pokemons: [])
         let pokemons = try await sut.fetchList(offset: 4)
-        XCTAssertEqual(pokemons.isEmpty, true)
+        #expect(pokemons.isEmpty == true)
     }
 }
 

--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/UseCase/ListUseCaseTest.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/UseCase/ListUseCaseTest.swift
@@ -5,15 +5,15 @@
 //  Created by Mark Chen on 2023/4/14.
 //
 
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
-final class ListUseCaseTest: XCTestCase {
+@Suite struct ListUseCaseTest {
     func test_listUseCase_fetchList_result() async throws {
         let sut = makeSUT(data: listStubData)
         let model = try await sut.fetchList(offset: 0)
-        XCTAssertEqual(model.first?.name, dummyName)
-        XCTAssertEqual(model.first?.id, dummyID)
+        #expect(model.first?.name == dummyName)
+        #expect(model.first?.id == dummyID)
     }
 
     func test_listUseCase_fetchList_empty_result() async throws {
@@ -24,7 +24,7 @@ final class ListUseCaseTest: XCTestCase {
         """.data(using: .utf8)!
         let sut = makeSUT(data: data)
         let model = try await sut.fetchList(offset: 0)
-        XCTAssertEqual(model.isEmpty, true)
+        #expect(model.isEmpty == true)
     }
 }
 

--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/UseCase/PokemonStoreUseCaseTest.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/UseCase/PokemonStoreUseCaseTest.swift
@@ -5,13 +5,13 @@
 //  Created by Mark Chen on 2023/4/15.
 //
 
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
-final class PokemonStoreUseCaseTest: XCTestCase {
+@Suite struct PokemonStoreUseCaseTest {
     func test_pokemonStoreUseCase_init() {
         let sut = makeSUT()
-        XCTAssertEqual(sut.getPokemon(id: dummyID)?.id, nil)
+        #expect(sut.getPokemon(id: dummyID)?.id == nil)
     }
 
     func test_pokemonStoreUseCase_setAndGetMethod() {
@@ -20,22 +20,22 @@ final class PokemonStoreUseCaseTest: XCTestCase {
         sut.savePokemon(name: dummyName, id: dummyID, isFavorite: true)
         sut.savePokemon(name: dummyName, id: otherID, isFavorite: false)
         
-        XCTAssertEqual(sut.getPokemon(id: dummyID)!.isFavorite, true)
-        XCTAssertEqual(sut.getPokemon(id: dummyID)!.name, dummyName)
+        #expect(sut.getPokemon(id: dummyID)!.isFavorite == true)
+        #expect(sut.getPokemon(id: dummyID)!.name == dummyName)
     }
 
     func test_pokemonStoreUseCase_notFound_pokemon() {
         let otherID = "id2"
         let sut = makeSUT()
         sut.savePokemon(name: dummyName, id: dummyID, isFavorite: true)
-        XCTAssertEqual(sut.getPokemon(id: otherID)?.id, nil)
+        #expect(sut.getPokemon(id: otherID)?.id == nil)
     }
 
     func test_pokemonStoreUseCase_update_pokemon_isFavorite() {
         let sut = makeSUT()
         sut.savePokemon(name: dummyName, id: dummyID, isFavorite: true)
         sut.savePokemon(name: dummyName, id: dummyID, isFavorite: false)
-        XCTAssertEqual(sut.getPokemon(id: dummyID)?.isFavorite, false)
+        #expect(sut.getPokemon(id: dummyID)?.isFavorite == false)
     }
 
 }

--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/ViewModel/FavoriteViewModelTest.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/ViewModel/FavoriteViewModelTest.swift
@@ -7,33 +7,33 @@
 
 import Combine
 import Foundation
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
-final class FavoriteViewModelTest: XCTestCase {
+@Suite struct FavoriteViewModelTest {
     func test_favoriteViewModel_storeIsEmpty() {
         let mockStore = MockStore(array: [])
         let sut = makeSUT(store: mockStore, id: dummyID, name: dummyName)
-        XCTAssertEqual(sut.isFavorite, false)
+        #expect(sut.isFavorite == false)
 
         sut.setIsFavorite(true)
-        XCTAssertEqual(sut.isFavorite, true)
+        #expect(sut.isFavorite == true)
     }
 
     func test_favoriteViewModel_hadStoredIsFavorite() {
         let mockStore = MockStore(array: [.init(name: dummyName, id: dummyID, isFavorite: true)])
         let sut = makeSUT(store: mockStore, id: dummyID, name: dummyName)
-        XCTAssertEqual(sut.isFavorite, true)
+        #expect(sut.isFavorite == true)
 
         sut.setIsFavorite(false)
-        XCTAssertEqual(sut.isFavorite, false)
+        #expect(sut.isFavorite == false)
     }
 
     func test_favoriteViewModel_emptyStore_notificationShouldUpdate() {
         let mockStore = MockStore(array: [])
         let sut = makeSUT(store: mockStore, id: dummyID, name: dummyName)
         sut.shouldUpdate(userInfo: .init(id: dummyID, isFavorite: true))
-        XCTAssertEqual(sut.isFavorite, true)
+        #expect(sut.isFavorite == true)
     }
 
 
@@ -41,7 +41,7 @@ final class FavoriteViewModelTest: XCTestCase {
         let mockStore = MockStore(array: [.init(name: dummyName, id: dummyID, isFavorite: false)])
         let sut = makeSUT(store: mockStore, id: dummyID, name: dummyName)
         sut.shouldUpdate(userInfo: .init(id: dummyID, isFavorite: true))
-        XCTAssertEqual(sut.isFavorite, true)
+        #expect(sut.isFavorite == true)
     }
 }
 

--- a/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/ViewModel/ListViewModelTest.swift
+++ b/AnotherPokemonAssignment/AnotherPokemonAssignmentTests/ViewModel/ListViewModelTest.swift
@@ -7,25 +7,20 @@
 
 import Combine
 import Foundation
-import XCTest
+import Testing
 @testable import AnotherPokemonAssignment
 
-final class ListViewModelTest: XCTestCase {
-    private var cancelBag = Set<AnyCancellable>()
-
-    override func tearDown() {
-        super.tearDown()
-        cancelBag = []
-    }
+@Suite struct ListViewModelTest {
 
     func test_listViewModel_fetchList() {
+        var cancelBag = Set<AnyCancellable>()
         let mock = ListServiceStub(data: listStubData)
         let sut = makeSUT(listService: mock)
         sut.$pokemons
             .filter { !$0.isEmpty }
             .receive(on: DispatchQueue.main)
             .sink { pokemons in
-                XCTAssertEqual(pokemons.count, mock.getListEntity()?.results.count)
+                #expect(pokemons.count == mock.getListEntity()?.results.count)
             }
             .store(in: &cancelBag)
 


### PR DESCRIPTION
## Summary
- replace XCTestCase subclass tests with Swift Testing suites
- update Helper utilities for new framework
- remove XCTest imports and use `@Suite` & `#expect`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6841b2b5723c832da763aa366e3d0509